### PR TITLE
Add mule-like metadata to `safeRead`

### DIFF
--- a/http-module/src/main/resources/dw/io/http/BodyUtils.dwl
+++ b/http-module/src/main/resources/dw/io/http/BodyUtils.dwl
@@ -15,6 +15,18 @@ fun normalizeHeaders(headers: Null): {_?: String} =
   {}
 
 /**
+* Removes all the parameters from a given MIME type
+**/
+fun mimeWithoutParameters(mime: String) = do {
+    var separator = indexOf(mime, ';')
+    ---
+    if (separator == -1)
+        mime
+    else
+        mime[0 to separator - 1]
+}
+
+/**
 * Normalize the object to be compliant with the http header
 *
 * === Parameters
@@ -77,5 +89,9 @@ fun safeRead(mime: String, payload: String | Binary | Null, readerOptions: Objec
                   ).result
             }
         }
-
+  } <~ {
+      contentLength: sizeOf(payload),
+      mediaType: mime,
+      mimeType: mimeWithoutParameters(mime),
+      raw: payload,
   }


### PR DESCRIPTION
This change adds the following properties to the results of `safeRead`:
-  contentLength: The number of bytes of the original payload
- mediaType: The MIME Type with its parametrization (basically the value of Content-Type
- mimeType: The MIME Type **without** its parametrization
- raw: The original payload before parsing

These properties are modelled as close as possible to their Mule counterparts[^1]. The only big exception is that we are not adding an "encoding" property for now.

[^1]: https://docs.mulesoft.com/dataweave/2.5/dataweave-cookbook-extract-data#metadata_selector